### PR TITLE
enable localization

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -55,6 +55,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    'django.middleware.locale.LocaleMiddleware',
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -120,6 +121,8 @@ AUTH_PASSWORD_VALIDATORS = [
 # https://docs.djangoproject.com/en/5.0/topics/i18n/
 
 LANGUAGE_CODE = "en-us"
+
+USE_I18N = True
 
 TIME_ZONE = "UTC"
 


### PR DESCRIPTION
Add `USE_I18N = True` to settings.

For the localization to work, we also need to configure the language in the browser settings
